### PR TITLE
Correctly encode the sha256 hash in Gopkg.lock files.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -8,6 +8,7 @@ const spdxLicenses = require("./spdx-licenses.json");
 const knownLicenses = require("./known-licenses.json");
 const cheerio = require("cheerio");
 const yaml = require("js-yaml");
+const ssri = require("ssri");
 
 /**
  * Method to get files matching a pattern
@@ -869,7 +870,7 @@ const parseGopkgData = async function (gopkgData) {
       value = tmpA[1].trim().replace(/\"/g, "");
       switch (key) {
         case "digest":
-          pkg._integrity = value.replace("1:", "sha256-");
+          pkg._integrity = ssri.fromHex(value.substring(2), "sha256");
           break;
         case "name":
           pkg.group = path.dirname(value);


### PR DESCRIPTION
While importing the generated SBOM into DependencyTrack, I encountered an error that a SHA-256 hash was too long. After further investigation, I found that the utility is not correctly representing the digest taken from Gopkg.lock, as it is in hex form and not base64 encoded as the `ssri` package expects.