### PR TITLE
Revert "Correctly encode the sha256 hash in Gopkg.lock files."

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -8,7 +8,6 @@ const spdxLicenses = require("./spdx-licenses.json");
 const knownLicenses = require("./known-licenses.json");
 const cheerio = require("cheerio");
 const yaml = require("js-yaml");
-const ssri = require("ssri");
 
 /**
  * Method to get files matching a pattern
@@ -870,7 +869,7 @@ const parseGopkgData = async function (gopkgData) {
       value = tmpA[1].trim().replace(/\"/g, "");
       switch (key) {
         case "digest":
-          pkg._integrity = ssri.fromHex(value.substring(2), "sha256");
+          pkg._integrity = value.replace("1:", "sha256-");
           break;
         case "name":
           pkg.group = path.dirname(value);


### PR DESCRIPTION
Reverts AppThreat/cdxgen#17

Breaking tests. There might be a different issue or a fix.