### PR TITLE
bugfix/everit plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,12 +387,12 @@ const createJavaBom = async (
       const f = pomFiles[i];
       const basePath = pathLib.dirname(f);
       console.log(
-        "Executing 'mvn org.cyclonedx:cyclonedx-maven-plugin:2.1.0:makeAggregateBom' in",
+        "Executing 'mvn dependency:get -DrepoUrl=https://jitpack.io -Dartifact=com.github.everit-org.json-schema:org.everit.json.schema:1.12.1 org.cyclonedx:cyclonedx-maven-plugin:2.1.0:makeAggregateBom' in",
         basePath
       );
       result = spawnSync(
         MVN_CMD,
-        ["org.cyclonedx:cyclonedx-maven-plugin:2.1.0:makeAggregateBom"],
+        ["dependency:get", "-DrepoUrl=https://jitpack.io", "-Dartifact=com.github.everit-org.json-schema:org.everit.json.schema:1.12.1", "org.cyclonedx:cyclonedx-maven-plugin:2.1.0:makeAggregateBom"],
         { cwd: basePath, encoding: "utf-8" }
       );
       if (result.status == 1 || result.error) {
@@ -462,7 +462,7 @@ const createJavaBom = async (
       // Enable execute permission
       try {
         fs.chmodSync(pathLib.join(path, "gradlew"), 0o775);
-      } catch (e) {}
+      } catch (e) { }
       GRADLE_CMD = pathLib.join(path, "gradlew");
     }
     let pkgList = [];

--- a/index.js
+++ b/index.js
@@ -462,7 +462,7 @@ const createJavaBom = async (
       // Enable execute permission
       try {
         fs.chmodSync(pathLib.join(path, "gradlew"), 0o775);
-      } catch (e) { }
+      } catch (e) {}
       GRADLE_CMD = pathLib.join(path, "gradlew");
     }
     let pkgList = [];


### PR DESCRIPTION
Closes [sast-scan #229](https://github.com/ShiftLeftSecurity/sast-scan/issues/229)
The required plugin is downloaded previously from the external repository, getting the makeAggregateBom command ready to be ran.