### PR TITLE
Sbt accepts sbt-dir differently

### DIFF
--- a/index.js
+++ b/index.js
@@ -533,7 +533,7 @@ const createJavaBom = async (
       );
       const result = spawnSync(
         SBT_CMD,
-        ["--sbt-dir", tempSbtgDir, `dependencyList::toFile"${dlFile}"`],
+        ["-sbt-dir", tempSbtgDir, `dependencyList::toFile"${dlFile}"`],
         { cwd: basePath, encoding: "utf-8" }
       );
       if (result.status == 1 || result.error) {


### PR DESCRIPTION
Looks like it is `-sbt-dir` not `--sbt-dir`?