### PR TITLE
Custom sbt plugin to fetch dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -566,7 +566,7 @@ const createJavaBom = async (
         }
       }
     } else {
-      let SBT_CMD = "sbt";
+      let SBT_CMD = process.env.SBT_CMD || "sbt";
       let tempDir = fs.mkdtempSync(pathLib.join(os.tmpdir(), "cdxsbt-"));
       let tempSbtgDir = fs.mkdtempSync(pathLib.join(os.tmpdir(), "cdxsbtg-"));
       fs.mkdirSync(tempSbtgDir, { recursive: true });

--- a/index.js
+++ b/index.js
@@ -556,7 +556,6 @@ const createJavaBom = async (
 
   if (sbtFiles && sbtFiles.length) {
     let pkgList = [];
-    // If the project use sbt lock files
     if (sbtLockFiles && sbtLockFiles.length) {
       for (let i in sbtLockFiles) {
         const f = sbtLockFiles[i];
@@ -566,55 +565,90 @@ const createJavaBom = async (
         }
       }
     } else {
-      // Attempt to create dependency graph via global plugin. Very limited support.
-      let SBT_CMD = process.env.SBT_CMD || "sbt";
+      let SBT_CMD = "sbt";
       let tempDir = fs.mkdtempSync(pathLib.join(os.tmpdir(), "cdxsbt-"));
       let tempSbtgDir = fs.mkdtempSync(pathLib.join(os.tmpdir(), "cdxsbtg-"));
-      tempSbtgDir = pathLib.join(tempSbtgDir, "1.0", "plugins");
       fs.mkdirSync(tempSbtgDir, { recursive: true });
-      // Create temporary global plugins
-      fs.writeFileSync(
-        pathLib.join(tempSbtgDir, "build.sbt"),
-        `addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")\n`
+      // Create temporary plugins file
+      let tempSbtPlugins = pathLib.join(tempSbtgDir, "dep-plugins.sbt")
+      // TODO: change to official forked version once it is available/
+      // Requires `--append` for `toFile` subtask.
+      fs.writeFileSync(tempSbtPlugins,
+        `addSbtPlugin("com.michaelpollmeier" % "sbt-dependency-graph" % "0.10.0-RC1+8-7f17b203+20210129-2104")\n`
       );
-      for (let i in sbtFiles) {
-        const f = sbtFiles[i];
-        const basePath = pathLib.dirname(f);
-        let dlFile = pathLib.join(tempDir, "dl-" + i + ".tmp");
-        console.log(
-          "Executing",
-          SBT_CMD,
-          "dependencyList in",
-          basePath,
-          "using plugins",
-          tempSbtgDir
-        );
-        const result = spawnSync(
-          SBT_CMD,
-          ["--sbt-dir", tempSbtgDir, `dependencyList::toFile"${dlFile}"`],
-          { cwd: basePath, encoding: "utf-8" }
-        );
-        if (result.status == 1 || result.error) {
+
+      // 1. Run dependency analysis on a root sbt file
+      let dlFile = pathLib.join(tempDir, "dl.tmp");
+      console.log(
+        "Executing",
+        SBT_CMD,
+        "dependencyList in",
+        path,
+        "using plugins",
+        tempSbtPlugins
+      );
+      const result = spawnSync(
+        SBT_CMD,
+        [`--addPluginSbtFile=${tempSbtPlugins}`,`dependencyList::toFile "${dlFile}" --append`],
+        { cwd: path, encoding: "utf-8" }
+      );
+      if (result.status == 1 || result.error) {
+        if (DEBUG_MODE) {
           console.error(result.stdout, result.stderr);
-          if (DEBUG_MODE) {
-            console.log(
-              `1. Check if scala and sbt is installed and available in PATH. Only scala 2.10 + sbt 0.13.6+ and 2.12 + sbt 1.0+ is supported for now.`
-            );
-            console.log(
-              `2. Check if the plugin net.virtual-void:sbt-dependency-graph 0.10.0-RC1 can be used in the environment`
-            );
-            console.log(
-              "3. Consider creating a lockfile using sbt-dependency-lock plugin. See https://github.com/stringbean/sbt-dependency-lock"
-            );
-          }
-        } else if (DEBUG_MODE) {
-          console.log(result.stdout);
         }
+        fs.unlinkSync(tempSbtPlugins)
+        // 2. Fallback, try with individual sbt files
+        for (let i in sbtFiles) {
+          const f = sbtFiles[i];
+          const basePath = pathLib.dirname(f);
+          let dlFile = pathLib.join(tempDir, "dl-" + i + ".tmp");
+          console.log(
+            "Executing",
+            SBT_CMD,
+            "dependencyList in",
+            basePath,
+            "using plugins",
+            tempSbtgDir
+          );
+          const result = spawnSync(
+            SBT_CMD,
+            ["--sbt-dir", tempSbtgDir, `dependencyList::toFile"${dlFile}"`],
+            { cwd: basePath, encoding: "utf-8" }
+          );
+          if (result.status == 1 || result.error) {
+            console.error(result.stdout, result.stderr);
+            if (DEBUG_MODE) {
+              console.log(
+                `1. Check if scala and sbt is installed and available in PATH. Only scala 2.10 + sbt 0.13.6+ and 2.12 + sbt 1.0+ is supported for now.`
+              );
+              console.log(
+                `2. Check if the plugin net.virtual-void:sbt-dependency-graph 0.10.0-RC1 can be used in the environment`
+              );
+              console.log(
+                "3. Consider creating a lockfile using sbt-dependency-lock plugin. See https://github.com/stringbean/sbt-dependency-lock"
+              );
+            }
+          } else if (DEBUG_MODE) {
+            console.log(result.stdout);
+          }
+          if (fs.existsSync(dlFile)) {
+            const cmdOutput = fs.readFileSync(dlFile, { encoding: "utf-8" });
+            if (DEBUG_MODE) {
+              console.log(cmdOutput);
+            }
+            const dlist = utils.parseKVDep(cmdOutput);
+            if (dlist && dlist.length) {
+              pkgList = pkgList.concat(dlist);
+            }
+          } else {
+            if (DEBUG_MODE) {
+              console.log(`sbt dependencyList did not yield ${dlFile}`);
+            }
+          }
+        }
+      } else {
         if (fs.existsSync(dlFile)) {
           const cmdOutput = fs.readFileSync(dlFile, { encoding: "utf-8" });
-          if (DEBUG_MODE) {
-            console.log(cmdOutput);
-          }
           const dlist = utils.parseKVDep(cmdOutput);
           if (dlist && dlist.length) {
             pkgList = pkgList.concat(dlist);
@@ -629,6 +663,7 @@ const createJavaBom = async (
     if (DEBUG_MODE) {
       console.log(`Found ${pkgList.length} packages`);
     }
+    // Note: this call can be expensive
     pkgList = await utils.getMvnMetadata(pkgList);
     // Should we attempt to resolve class names
     if (options.resolveClass) {


### PR DESCRIPTION
Using `--sbt-dir` to setup `sbt-dependency-graph` has rather serious
limitations that prevent us from initializing sbt and running the
plugin.
Instead, we add the plugin info with `addPluginSbtFile` and run sbt in
the root path of the project.
`dependencyList::toFile` is problematic for multi-project setups because
it prevents us from writing to the same file for subprojects. Using
`--force` will only override the write and save the dependency list from
the last project analyzed, whichever that might be.

I forked the original project and added `--append` to the original
`toFile` subtask to support bulk collection of dependencies.
We "could" instead look at the list of projects and run `dependencyList`
on each of them but that requires cumbersome and fragile sbt output
parsing.

Note1: We are currently relying on `sbt-dependency-graph` released
quickly to `com.michaelpollmeier` organization. Will switch to
`io.shiftleft` once it lands on Sonatype.
Note2: I didn't try to push a patch upstream as elements of
`sbt-dependency-graph` have been integrated in sbt 1.4.0 and it's
unlikely any work will continue on the plugin itself. We might still
want to provide a similar patch to sbt itself but it will be a longer
path.