### PR TITLE
Fix parsing issues

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -260,7 +260,12 @@ const parseYarnLock = async function (yarnLockFile) {
         return;
       }
       if (!l.startsWith(" ")) {
-        const tmpA = l.split("@");
+        // strip surrounding quotes, if any
+        const tmpA = l.replace(/["']/g, '').split("@");
+        // ignore possible leading empty strings
+        if (tmpA[0] === '') {
+          tmpA.shift();
+        }
         if (tmpA.length >= 2) {
           const fullName = tmpA[0];
           if (fullName.indexOf("/") > -1) {

--- a/utils.js
+++ b/utils.js
@@ -261,7 +261,7 @@ const parseYarnLock = async function (yarnLockFile) {
       }
       if (!l.startsWith(" ")) {
         const tmpA = l.split("@");
-        if (tmpA.length == 2) {
+        if (tmpA.length >= 2) {
           const fullName = tmpA[0];
           if (fullName.indexOf("/") > -1) {
             const parts = fullName.split("/");

--- a/utils.test.js
+++ b/utils.test.js
@@ -576,7 +576,7 @@ test("parsePnpmLock", async () => {
 
 test("parseYarnLock", async () => {
   let deps = await utils.parseYarnLock("./test/yarn.lock");
-  expect(deps.length).toEqual(51);
+  expect(deps.length).toEqual(56);
   expect(deps[0]).toEqual({
     group: '',
     name: 'asap',
@@ -585,12 +585,12 @@ test("parseYarnLock", async () => {
   });
 
   deps = await utils.parseYarnLock("./test/data/yarn_locks/yarn.lock");
-  expect(deps.length).toEqual(1463);
+  expect(deps.length).toEqual(2029);
   expect(deps[0]).toEqual({
-    group: '',
-    name: 'JSONStream',
-    version: '4.2.2',
-    _integrity: 'sha256-d291c6a4e97989b5c61d9acf396ae4fe133a718d'
+    group: 'babel',
+    name: 'cli',
+    version: '7.10.1',
+    _integrity: 'sha256-b6e5cd43a17b8f639442ab027976408ebe6d79a0'
   });
   deps.forEach(d => {
     expect(d.name).toBeDefined();


### PR DESCRIPTION
@prabhu This attempts to fix two parsing issues, one related to comma-delimited package declarations, and the other related to "@-scoped" packages. I believe this minimal yarn.lock snippet demonstrates both edge cases here:

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1

"@apollo/client@^3.1.5":
  version "3.2.5"
  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.5.tgz#24e0a6faa1d231ab44807af237c6227410c75c4d"
  integrity sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
  dependencies:
    "@graphql-typed-document-node/core" "^3.0.0"
    "@types/zen-observable" "^0.8.0"
    "@wry/context" "^0.5.2"
    "@wry/equality" "^0.2.0"
    fast-json-stable-stringify "^2.0.0"
    graphql-tag "^2.11.0"
    hoist-non-react-statics "^3.3.2"
    optimism "^0.13.0"
    prop-types "^15.7.2"
    symbol-observable "^2.0.0"
    ts-invariant "^0.4.4"
    tslib "^1.10.0"
    zen-observable "^0.8.14"

ms@2.1.2, ms@^2.1.1, ms@^2.1.2:
  version "2.1.2"
  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==

mustache@~4.1.0:
  version "4.1.0"
  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.1.0.tgz#8c1b042238a982d2eb2d30efc6c14296ae3f699d"
  integrity sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==
```