### PR TITLE
Fixes #59 inadvertent dropping of packages ending in go

### DIFF
--- a/test/gomod/go.mod
+++ b/test/gomod/go.mod
@@ -3,7 +3,8 @@ module cdxgen/test
 go 1.14
 
 require (
-    google.golang.org/grpc v1.32.0
+    google.golang.org/grpc v1.32.
+    github.com/aws/aws-sdk-go v1.38.47
     github.com/spf13/viper v1.3.0
     github.com/spf13/cobra v1.0.0
 )

--- a/test/gomod/go.mod
+++ b/test/gomod/go.mod
@@ -3,7 +3,7 @@ module cdxgen/test
 go 1.14
 
 require (
-    google.golang.org/grpc v1.32.
+    google.golang.org/grpc v1.32.0
     github.com/aws/aws-sdk-go v1.38.47
     github.com/spf13/viper v1.3.0
     github.com/spf13/cobra v1.0.0

--- a/utils.js
+++ b/utils.js
@@ -1211,8 +1211,8 @@ const parseGoModData = async function (goModData, gosumMap) {
 
     // Skip go.mod file headers, whitespace, and/or comments
     if (
-      l.includes("module ") ||
-      l.includes("go ") ||
+      l.startsWith("module ") ||
+      l.startsWith("go ") ||
       l.includes(")") ||
       l.trim() === "" ||
       l.trim().startsWith("//")

--- a/utils.test.js
+++ b/utils.test.js
@@ -208,6 +208,7 @@ test("parseGoModData", async () => {
   const gosumMap = {
     "google.golang.org/grpc/v1.21.0":
       "sha256-oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=",
+    "github.com/aws/aws-sdk-go/v1.38.47":"sha256-fake-sha-for-aws-go-sdk=",
     "github.com/spf13/cobra/v1.0.0":
       "sha256-/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=",
     "github.com/spf13/viper/v1.0.2":
@@ -219,22 +220,30 @@ test("parseGoModData", async () => {
     fs.readFileSync("./test/gomod/go.mod", (encoding = "utf-8")),
     gosumMap
   );
-  expect(dep_list.length).toEqual(3);
+  console.log(dep_list);
+  expect(dep_list.length).toEqual(4);
   expect(dep_list[0]).toEqual({
+    group: "github.com/aws",
+    name: "aws-sdk-go",
+    license: undefined,
+    version: "v1.38.47",
+    _integrity: "sha256-fake-sha-for-aws-go-sdk=",
+  });
+  expect(dep_list[1]).toEqual({
     group: "github.com/spf13",
     name: "cobra",
     license: undefined,
     version: "v1.0.0",
     _integrity: "sha256-/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=",
   });
-  expect(dep_list[1]).toEqual({
+  expect(dep_list[2]).toEqual({
     group: "google.golang.org",
     name: "grpc",
     license: undefined,
     version: "v1.21.0",
     _integrity: "sha256-oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=",
   });
-  expect(dep_list[2]).toEqual({
+  expect(dep_list[3]).toEqual({
     group: "github.com/spf13",
     name: "viper",
     license: undefined,


### PR DESCRIPTION
This fixes an issue (#59) with parsing go.mod files if they include package
references that end in go. For example, github.com/aws/aws-sdk-go.
The matching against the go.mod file is overly aggressive for keywords
like go in the file. This aggressive matching results in packages
being dropped from the scan.

This change ensures that the start of the line is used
in the matching for go and module keywords. I believe this is safe as
the go.mod files are uniform in construction (at least around these two
areas).

It may be worth making other matches for replace and require more
precise, but that is not part of the scope of this change.