### PR TITLE
Use go list and mod to improve BoM

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-20.04]
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/index.js
+++ b/index.js
@@ -1150,14 +1150,23 @@ const createGoBom = async (path, options) => {
         }
         const allImports = {};
         const circuitBreak = false;
+        if (DEBUG_MODE) {
+          console.log(
+            "Attempting to detect required packages using `go mod why` command"
+          );
+        }
         // Using go mod why detect required packages
         for (let apkg of pkgList) {
           if (circuitBreak) {
             break;
           }
+          let pkgFullName = `${apkg.group}/${apkg.name}`;
+          if (DEBUG_MODE) {
+            console.log(`go mod why -m -vendor ${pkgFullName}`);
+          }
           const mresult = spawnSync(
             "go",
-            ["mod", "why", "-m", "-vendor", apkg],
+            ["mod", "why", "-m", "-vendor", pkgFullName],
             { cwd: path, encoding: "utf-8", timeout: TIMEOUT_MS }
           );
           if (mresult.status == 1 || mresult.error) {
@@ -1167,8 +1176,8 @@ const createGoBom = async (path, options) => {
             if (mstdout) {
               const cmdOutput = Buffer.from(mstdout).toString();
               let whyPkg = utils.parseGoModWhy(cmdOutput);
-              if (whyPkg) {
-                allImports[whyPkg] = true;
+              if (whyPkg == pkgFullName) {
+                allImports[pkgFullName] = true;
               }
             }
           }

--- a/index.js
+++ b/index.js
@@ -1124,6 +1124,66 @@ const createGoBom = async (path, options) => {
     (options.multiProject ? "**/" : "") + "go.mod"
   );
   if (gomodFiles.length) {
+    // Use the go list -deps and go mod why commands to generate a good quality BoM for non-docker invocations
+    if (options.projectType !== "docker") {
+      console.log("Executing go list -deps in", path);
+      const result = spawnSync(
+        "go",
+        [
+          "list",
+          "-deps",
+          "-f",
+          "'{{with .Module}}{{.Path}} {{.Version}}{{end}}'",
+          "./...",
+        ],
+        { cwd: path, encoding: "utf-8", timeout: TIMEOUT_MS }
+      );
+      if (result.status == 1 || result.error) {
+        console.error(result.stdout, result.stderr);
+      }
+      const stdout = result.stdout;
+      if (stdout) {
+        const cmdOutput = Buffer.from(stdout).toString();
+        const dlist = await utils.parseGoListDep(cmdOutput, gosumMap);
+        if (dlist && dlist.length) {
+          pkgList = pkgList.concat(dlist);
+        }
+        const allImports = {};
+        const circuitBreak = false;
+        // Using go mod why detect required packages
+        for (let apkg of pkgList) {
+          if (circuitBreak) {
+            break;
+          }
+          const mresult = spawnSync(
+            "go",
+            ["mod", "why", "-m", "-vendor", apkg],
+            { cwd: path, encoding: "utf-8", timeout: TIMEOUT_MS }
+          );
+          if (mresult.status == 1 || mresult.error) {
+            circuitBreak = true;
+          } else {
+            const mstdout = mresult.stdout;
+            if (mstdout) {
+              const cmdOutput = Buffer.from(mstdout).toString();
+              let whyPkg = utils.parseGoModWhy(cmdOutput);
+              if (whyPkg) {
+                allImports[whyPkg] = true;
+              }
+            }
+          }
+        }
+        return buildBomNSData(pkgList, "golang", {
+          allImports,
+          src: path,
+          filename: gomodFiles.join(", "),
+        });
+      }
+    }
+    // Parse the gomod files manually. The resultant BoM would be incomplete
+    console.log(
+      "Manually parsing go.mod files. The resultant BoM would be incomplete."
+    );
     for (let i in gomodFiles) {
       const f = gomodFiles[i];
       if (DEBUG_MODE) {

--- a/index.js
+++ b/index.js
@@ -1150,11 +1150,9 @@ const createGoBom = async (path, options) => {
         }
         const allImports = {};
         const circuitBreak = false;
-        if (DEBUG_MODE) {
-          console.log(
-            "Attempting to detect required packages using `go mod why` command"
-          );
-        }
+        console.log(
+          `Attempting to detect required packages using "go mod why" command for ${pkgList.length} packages`
+        );
         // Using go mod why detect required packages
         for (let apkg of pkgList) {
           if (circuitBreak) {
@@ -1181,6 +1179,9 @@ const createGoBom = async (path, options) => {
               }
             }
           }
+        }
+        if (DEBUG_MODE) {
+          console.log(`Required packages: ${Object.keys(allImports).length}`);
         }
         return buildBomNSData(pkgList, "golang", {
           allImports,

--- a/test/data/golist-dep.txt
+++ b/test/data/golist-dep.txt
@@ -1,0 +1,16 @@
+github.com/badoux/checkmail v0.0.0-20181210160741-9661bd69e9ad
+github.com/gomodule/oauth1 v0.0.0-20181215000758-9a59ed3b0a84
+github.com/gorilla/mux v1.7.4
+github.com/lib/pq v1.3.0
+github.com/lib/pq v1.3.0
+github.com/lib/pq v1.3.0
+github.com/go-chi/chi v4.0.0+incompatible
+github.com/mailru/easyjson v0.7.0
+github.com/mailru/easyjson v0.7.0
+github.com/mailru/easyjson v0.7.0
+github.com/mailru/easyjson v0.7.0
+github.com/mailgun/mailgun-go/v4 v4.0.1
+github.com/pkg/errors v0.9.1
+github.com/mailgun/mailgun-go/v4 v4.0.1
+github.com/Preetam/readfasterapp 
+github.com/Preetam/readfasterapp 

--- a/test/data/gomodwhy.txt
+++ b/test/data/gomodwhy.txt
@@ -1,0 +1,3 @@
+# github.com/mailgun/mailgun-go/v4
+github.com/Preetam/readfasterapp/api
+github.com/mailgun/mailgun-go/v4

--- a/test/data/gomodwhynot.txt
+++ b/test/data/gomodwhynot.txt
@@ -1,0 +1,2 @@
+# github.com/mailgun/mailgun-go/v5
+(main module does not need to vendor module github.com/mailgun/mailgun-go/v5)

--- a/utils.js
+++ b/utils.js
@@ -1244,7 +1244,7 @@ const parseGoModData = async function (goModData, gosumMap) {
         group = name;
       }
       const version = tmpA[1];
-      gosumHash = gosumMap[`${group}/${name}/${version}`];
+      let gosumHash = gosumMap[`${group}/${name}/${version}`];
       // The hash for this version was not found in go.sum, so skip as it is most likely being replaced.
       if (gosumHash === undefined) {
         continue;
@@ -1260,7 +1260,7 @@ const parseGoModData = async function (goModData, gosumMap) {
       }
       const version = tmpA[3];
 
-      gosumHash = gosumMap[`${group}/${name}/${version}`];
+      let gosumHash = gosumMap[`${group}/${name}/${version}`];
       // The hash for this version was not found in go.sum, so skip.
       if (gosumHash === undefined) {
         continue;
@@ -1274,6 +1274,68 @@ const parseGoModData = async function (goModData, gosumMap) {
   return pkgComponentsList;
 };
 exports.parseGoModData = parseGoModData;
+
+/**
+ * Parse go list output
+ *
+ * @param {string} rawOutput Output from go list invocation
+ * @returns List of packages
+ */
+const parseGoListDep = async function (rawOutput, gosumMap) {
+  if (typeof rawOutput === "string") {
+    const deps = [];
+    const keys_cache = {};
+    const pkgs = rawOutput.split("\n");
+    for (let i in pkgs) {
+      let l = pkgs[i];
+      const verArr = l.trim().replace(new RegExp("[\"']", "g"), "").split(" ");
+      if (verArr && verArr.length === 2) {
+        const key = verArr[0] + "-" + verArr[1];
+        // Filter duplicates
+        if (!keys_cache[key]) {
+          keys_cache[key] = key;
+          let group = path.dirname(verArr[0]);
+          const name = path.basename(verArr[0]);
+          const version = verArr[1];
+          if (group === ".") {
+            group = name;
+          }
+          let gosumHash = gosumMap[`${group}/${name}/${version}`];
+          let component = await getGoPkgComponent(
+            group,
+            name,
+            version,
+            gosumHash
+          );
+          deps.push(component);
+        }
+      }
+    }
+    return deps;
+  }
+  return [];
+};
+exports.parseGoListDep = parseGoListDep;
+
+/**
+ * Parse go mod why output
+ * @param {string} rawOutput Output from go mod why
+ * @returns package name or none
+ */
+const parseGoModWhy = function (rawOutput) {
+  if (typeof rawOutput === "string") {
+    let pkg_name = undefined;
+    const tmpA = rawOutput.split("\n");
+    tmpA.forEach((l) => {
+      if (l && !l.startsWith("#") && !l.startsWith("(")) {
+        pkg_name = l.trim();
+      }
+    });
+    return pkg_name;
+  }
+  return undefined;
+};
+exports.parseGoModWhy = parseGoModWhy;
 
 const parseGosumData = async function (gosumData) {
   const pkgList = [];

--- a/utils.test.js
+++ b/utils.test.js
@@ -208,7 +208,7 @@ test("parseGoModData", async () => {
   const gosumMap = {
     "google.golang.org/grpc/v1.21.0":
       "sha256-oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=",
-    "github.com/aws/aws-sdk-go/v1.38.47":"sha256-fake-sha-for-aws-go-sdk=",
+    "github.com/aws/aws-sdk-go/v1.38.47": "sha256-fake-sha-for-aws-go-sdk=",
     "github.com/spf13/cobra/v1.0.0":
       "sha256-/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=",
     "github.com/spf13/viper/v1.0.2":
@@ -293,6 +293,30 @@ test("parseGoSumData", async () => {
   dep_list.forEach((d) => {
     expect(d.license);
   });
+});
+
+test("parse go list dependencies", async () => {
+  let dep_list = await utils.parseGoListDep(
+    fs.readFileSync("./test/data/golist-dep.txt", (encoding = "utf-8")),
+    {}
+  );
+  expect(dep_list.length).toEqual(8);
+  expect(dep_list[0]).toEqual({
+    group: "github.com/badoux",
+    name: "checkmail",
+    version: "v0.0.0-20181210160741-9661bd69e9ad",
+  });
+});
+
+test("parse go mod why dependencies", () => {
+  let pkg_name = utils.parseGoModWhy(
+    fs.readFileSync("./test/data/gomodwhy.txt", (encoding = "utf-8"))
+  );
+  expect(pkg_name).toEqual("github.com/mailgun/mailgun-go/v4");
+  pkg_name = utils.parseGoModWhy(
+    fs.readFileSync("./test/data/gomodwhynot.txt", (encoding = "utf-8"))
+  );
+  expect(pkg_name).toBeUndefined();
 });
 
 test("parseGopkgData", async () => {


### PR DESCRIPTION
Uses go list -deps to get the list and then runs `go mod why -m -vendor` to set scope attribute to required or optional.

```
go list -deps -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' ./...
```

This makes the resulting BoM more complete and informational.

Fixes https://github.com/AppThreat/cdxgen/issues/62