### PR TITLE
await results when parsing pnpm lock files

### DIFF
--- a/index.js
+++ b/index.js
@@ -842,7 +842,7 @@ const createNodejsBom = async (path, options) => {
   if (pnpmLockFiles && pnpmLockFiles.length) {
     for (let i in pnpmLockFiles) {
       const f = pnpmLockFiles[i];
-      const dlist = utils.parsePnpmLock(f);
+      const dlist = await utils.parsePnpmLock(f);
       if (dlist && dlist.length) {
         pkgList = pkgList.concat(dlist);
       }


### PR DESCRIPTION
No results were being generated when running with any of the JavaScript types (e.g. -t nodejs/js/javascript/typescript/ts) on a pnpm project. The following check was never passing as utils.parsePkgLock() is an async function returning a Promise
```
if (dlist && dlist.length) {
    ...
}
```