### PR TITLE
Convert relative gradlew path into absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -679,7 +679,7 @@ const createJavaBom = async (path, options) => {
         try {
           fs.chmodSync(pathLib.join(path, "gradlew"), 0o775);
         } catch (e) {}
-        GRADLE_CMD = pathLib.join(path, "gradlew");
+        GRADLE_CMD = pathLib.resolve(pathLib.join(path, "gradlew"));
       }
       // Support for multi-project applications
       if (process.env.GRADLE_MULTI_PROJECT_MODE) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appthreat/cdxgen",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appthreat/cdxgen",
-      "version": "3.2.11",
+      "version": "3.2.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.16.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/cdxgen",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) from source or container image",
   "homepage": "http://github.com/AppThreat/cdxgen",
   "author": "Team AppThreat",


### PR DESCRIPTION
Hi, prabhu 

I found the bug when I generate the sbom with gradlew

```sh
$ cdxgen -o bom.json
Executing gradlew dependencies in my-test-project
null null
```

And I fixed it by resolving the path.
```sh
$ cdxgen -o bom.json
Executing /my/absolute/path/gradlew dependencies in my-test-project
BOM file written to bom.json
```