### PR TITLE
Don't stop on invalid composer.lock file.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2030,7 +2030,13 @@ exports.getNugetMetadata = getNugetMetadata;
 const parseComposerLock = function (pkgLockFile) {
   const pkgList = [];
   if (fs.existsSync(pkgLockFile)) {
-    const lockData = JSON.parse(fs.readFileSync(pkgLockFile, "utf8"));
+    let lockData = {};
+    try {
+      lockData = JSON.parse(fs.readFileSync(pkgLockFile, "utf8"));
+    } catch (e) {
+      console.error("Invalid composer.lock file:", pkgLockFile);
+      return [];
+    }
     if (lockData && lockData.packages) {
       for (let i in lockData.packages) {
         const pkg = lockData.packages[i];


### PR DESCRIPTION
Drupal 9 has an empty composer.lock file at `/core/modules/system/tests/fixtures/HtaccessTest/composer.lock`.
This should not prevent the creation of an SBOM.