### PR TITLE
Only remove leading 'v' from composer version

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2056,7 +2056,11 @@ const parseComposerLock = function (pkgLockFile) {
           pkgList.push({
             group: group,
             name: name,
-            version: pkg.version.replace("v", ""),
+            // Remove leading v from version to work around bug
+            //  https://github.com/OSSIndex/vulns/issues/231
+            // @TODO: remove workaround when DependencyTrack v4.4 is released,
+            //  which has it's own workaround. Or when the 231 bug is fixed.
+            version: pkg.version.replace(/^v/, ""),
             repository: pkg.source,
             license: pkg.license,
             description: pkg.description,


### PR DESCRIPTION
The character 'v' should only be removed if it's the 1st character. Removing it from versions like "1.0.0-dev" or "dev-master" is not good.
Also added a comment explaining why the version changing happens at all.