### PR TITLE
Fix missing pathLib.join when determining to use local gradlew

### DIFF
--- a/index.js
+++ b/index.js
@@ -678,7 +678,7 @@ const createJavaBom = async (path, options) => {
         GRADLE_CMD = pathLib.join(process.env.GRADLE_HOME, "bin", "gradle");
       }
       // Use local gradle wrapper if available
-      if (fs.existsSync(path, "gradlew")) {
+      if (fs.existsSync(pathLib.join(path, "gradlew"))) {
         // Enable execute permission
         try {
           fs.chmodSync(pathLib.join(path, "gradlew"), 0o775);


### PR DESCRIPTION
```
├─ java
│ ├─ app
│ ├─ build.gradle.kts
│ ├─ gradle
│ │ └── wrapper
│ │     ├── gradle-wrapper.jar
│ │     └── gradle-wrapper.properties
│ ├─ gradlew
│ ├─ gradlew.bat
│ ├─ settings.gradle.kts
│ └─ src
├─ kotlin
│ ├─ gradle
│ │ └── wrapper
│ │     ├── gradle-wrapper.jar
│ │     └── gradle-wrapper.properties
│ ├─ gradlew
│ ├─ gradlew.bat
│ ├─ lib
│ │ ├── build.gradle.kts
│ │ └── src
│ └── settings.gradle.kts
```
Without this change, unable to generate a BOM if multiple, unrelated, gradle projects are not in the root
```
$ bin/cdxgen -r -t kotlin  # or java
Executing /home/mike/dev/cdxgen/gradlew dependencies in /home/blyenth/dev/cdxgen/testing/java
null null
Executing /home/mike/dev/cdxgen/gradlew dependencies in /home/blyenth/dev/cdxgen/testing/kotlin/lib
null null
Unable to produce BOM for .
```

From my limited understanding of `fs.existsSync` it takes one argument, which would be path (`.`), this would always return `true`

Output with the change and the BOM has all the correct information from both projects / directories.
```
$ bin/cdxgen -r -t java -o projects.json
Executing gradle dependencies in /home/mike/dev/cdxgen/testing/java
Executing gradle dependencies in /home/mike/dev/cdxgen/testing/kotlin/lib
BOM file written to projects.json
```