### PR TITLE
Fix TypeError for parsePiplockData when VCS is used without version

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1208,8 +1208,10 @@ const parsePiplockData = async function (lockData) {
       const depBlock = lockData[k];
       Object.keys(depBlock).forEach((p) => {
         const pkg = depBlock[p];
-        let versionStr = pkg.version.replace("==", "");
-        pkgList.push({ name: p, version: versionStr });
+        if (pkg.hasOwnProperty("version")) {
+          let versionStr = pkg.version.replace("==", "");
+          pkgList.push({ name: p, version: versionStr });
+        }
       });
     });
   return await getPyMetadata(pkgList, false);


### PR DESCRIPTION
When a VCS dependency is defined without a version (or ref),
```
[packages]
requests = {git = "https://github.com/requests/requests.git", editable = true}
```

we receive the following:

```
$ cdxgen
/usr/lib/node_modules/@appthreat/cdxgen/utils.js:1212
	    let versionStr = pkg.version.replace("==", "");
	                                 ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at /usr/lib/node_modules/@appthreat/cdxgen/utils.js:1212:35
    at Array.forEach (<anonymous>)
    at /usr/lib/node_modules/@appthreat/cdxgen/utils.js:1210:3
    at Array.forEach (<anonymous>)
    at Object.parsePiplockData (/usr/lib/node_modules/@appthreat/cdxgen/utils.js:1207:6)
    at createPythonBom (/usr/lib/node_modules/@appthreat/cdxgen/index.js:1384:31)
    at createXBom (/usr/lib/node_modules/@appthreat/cdxgen/index.js:2441:18)
    at Object.exports.createBom (/usr/lib/node_modules/@appthreat/cdxgen/index.js:2688:22)
    at /usr/lib/node_modules/@appthreat/cdxgen/bin/cdxgen:96:32
    at Object.<anonymous> (/usr/lib/node_modules/@appthreat/cdxgen/bin/cdxgen:170:3)
```