### PR TITLE
Issue 148:  ERR_OUT_OF_RANGE setting environment variable CDXGEN_TIMEOUT_MS

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const HASH_PATTERN =
   "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$";
 
 // Timeout milliseconds. Default 10 mins
-const TIMEOUT_MS = process.env.CDXGEN_TIMEOUT_MS || 10 * 60 * 1000;
+const TIMEOUT_MS = parseInt(process.env.CDXGEN_TIMEOUT_MS) || 10 * 60 * 1000;
 
 /**
  * Method to create global external references


### PR DESCRIPTION
Wraps CDXGEN_TIMEOUT_MS in a parseInt statement as this is received from the command line as a String