### PR TITLE
Bug fix: C# project (.csproj) parsing error

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2448,7 +2448,7 @@ const parseCsProjData = async function (csProjData) {
       for (let j in item.PackageReference) {
         const pref = item.PackageReference[j].$;
         let pkg = { group: "" };
-        if (pref.Include.includes(".csproj")) {
+        if (!pref.Include || pref.Include.includes(".csproj")) {
           continue;
         }
         pkg.name = pref.Include;


### PR DESCRIPTION
According to Microsoft's specification [[1]](https://learn.microsoft.com/en-us/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file) [[2]](https://learn.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild?view=vs-2022) PackageReference element of Microsoft Build Engine project files could contain attributes other than "Include", i.e "Update":
```
<ItemGroup>
            <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
</ItemGroup>
```
So without this change, there will be an undefined reference exception when trying to parse such ASP.NET project files:
```
TypeError: Cannot read properties of undefined (reading 'includes')
    at Object.parseCsProjData (C:\snapshot\cdxgen\utils.js:2451:26)
    at createCsharpBom (C:\snapshot\cdxgen\index.js:2251:33)
    at process.runNextTicks [as _tickCallback] (node:internal/process/task_queues:61:5)
    at Function.runMain (pkg/prelude/bootstrap.js:1984:13)
    at node:internal/main/run_main_module:17:47
    at async createMultiXBom (C:\snapshot\cdxgen\index.js:2383:15)
    at async Object.createBom (C:\snapshot\cdxgen\index.js:2805:16)
    at async C:\snapshot\cdxgen\bin\cdxgen:105:22
```