### PR TITLE
Added support for "strict" gradle dependencies

### DIFF
--- a/test/data/gradle-android-dep.out
+++ b/test/data/gradle-android-dep.out
@@ -846,6 +846,8 @@ releaseUnitTestRuntimeClasspath - Resolved configuration for runtime for variant
 |    \--- com.squareup.okio:okio:1.13.0
 \--- junit:junit:4.12
      \--- org.hamcrest:hamcrest-core:1.3
++--- androidx.print:print:{strictly 1.0.0} -> 1.0.0 (c)
++--- androidx.core:core:1.1.0 -> 1.7.0 (*)
 
 releaseWearApp - Link to a wear app to embed for object 'release'. (n)
 No dependencies

--- a/utils.js
+++ b/utils.js
@@ -680,7 +680,7 @@ const parseGradleDep = function (rawOutput) {
     const deps = [];
     const keys_cache = {};
     const depRegex =
-      /^.*?--- +(?<group>[^\s:]+):(?<name>[^\s:]+)(?::(?<versionspecified>[^\s:]+))?(?: +-> +(?<versionoverride>[^\s:]+))?/gm;
+    /^.*?--- +(?<group>[^\s:]+):(?<name>[^\s:]+)(?::(?:{strictly )?(?<versionspecified>[^\s:}]+))?(?:})?(?: +-> +(?<versionoverride>[^\s:]+))?/gm;
     while ((match = depRegex.exec(rawOutput))) {
       const [, group, name, versionspecified, versionoverride] = match;
       const version = versionoverride || versionspecified;

--- a/utils.test.js
+++ b/utils.test.js
@@ -88,7 +88,7 @@ test("parse gradle dependencies", () => {
   dep_list = utils.parseGradleDep(
     fs.readFileSync("./test/data/gradle-android-dep.out", (encoding = "utf-8"))
   );
-  expect(dep_list.length).toEqual(103);
+  expect(dep_list.length).toEqual(105);
   expect(dep_list[0]).toEqual({
     group: "com.android.support.test",
     name: "runner",
@@ -96,6 +96,22 @@ test("parse gradle dependencies", () => {
       type: "jar",
     },
     version: "1.0.2",
+  });
+  expect(dep_list[103]).toEqual({
+    group: "androidx.print",
+    name: "print",
+    qualifiers: {
+      type: "jar",
+    },
+    version: "1.0.0",
+  });
+  expect(dep_list[104]).toEqual({
+    group: "androidx.core",
+    name: "core",
+    qualifiers: {
+      type: "jar",
+    },
+    version: "1.7.0",
   });
   dep_list = utils.parseGradleDep(
     fs.readFileSync("./test/data/gradle-out1.dep", (encoding = "utf-8"))


### PR DESCRIPTION
Good day

I tried using this tool to generate a BOM for an android project and noticed some strange behavior.

Some of the dependency versions were picked up as "{strictly" instead of the actual version e.g. "1.0.0".

Upon further investigation I noticed that the current parser expects it to be a version number, which in this case it is not.

If you create a new project in Android Studio and run the following command
```
./gradlew :app:dependencies -q --console plain
```
You will notice that some of the output items include the word "{strictly" in the version number
```
+--- androidx.core:core:{strictly 1.7.0} -> 1.7.0 (c)
```
The generated BOM entry looks like this
```
{
    "group": "androidx.core",
    "name": "core",
    "version": "{strictly",
    "description": "",
    "licenses": [],
    "purl": "pkg:maven/androidx.core/core@{strictly?type=jar",
    "type": "library",
    "bom-ref": "pkg:maven/androidx.core/core@{strictly?type=jar"
}
```
I have updated the parser regex to ignore the "{strictly" and "}" part of the dependency and tested it locally.

The generated BOM entry looks like this
```
{
    "group": "androidx.core",
    "name": "core",
    "version": "1.7.0",
    "description": "",
    "licenses": [],
    "purl": "pkg:maven/androidx.core/core@1.7.0?type=jar",
    "type": "library",
    "bom-ref": "pkg:maven/androidx.core/core@1.7.0?type=jar"
}
```
I am not sure if this is a gradle version issue, my gradle information is as follows
```
------------------------------------------------------------
Gradle 7.4
------------------------------------------------------------

Build time:   2022-02-08 09:58:38 UTC
Revision:     f0d9291c04b90b59445041eaa75b2ee744162586

Kotlin:       1.5.31
Groovy:       3.0.9
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          11.0.16 (Ubuntu 11.0.16+8-post-Ubuntu-0ubuntu122.04)
OS:           Linux 5.15.0-48-generic amd64
```
It is worth noting that I am by no means a regex expert and I would appreciate someone with a bit more knowledge to check it out and provide any feedback / changes that might improve it.

Thanks,