### PR TITLE
on windows, look for the bat versions

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -3131,19 +3131,25 @@ exports.readZipEntry = readZipEntry;
  */
 const getGradleCommand = (srcPath, rootPath) => {
   let gradleCmd = "gradle";
-  if (fs.existsSync(path.join(srcPath, "gradlew"))) {
+
+  let findGradleFile = "gradlew";
+  if (os.platform() == "win32") {
+    findGradleFile = "gradlew.bat";
+  }
+
+  if (fs.existsSync(path.join(srcPath, findGradleFile))) {
     // Use local gradle wrapper if available
     // Enable execute permission
     try {
-      fs.chmodSync(path.join(srcPath, "gradlew"), 0o775);
+      fs.chmodSync(path.join(srcPath, findGradleFile), 0o775);
     } catch (e) {}
-    gradleCmd = path.resolve(path.join(srcPath, "gradlew"));
-  } else if (rootPath && fs.existsSync(path.join(rootPath, "gradlew"))) {
+    gradleCmd = path.resolve(path.join(srcPath, findGradleFile));
+  } else if (rootPath && fs.existsSync(path.join(rootPath, findGradleFile))) {
     // Check if the root directory has a wrapper script
     try {
-      fs.chmodSync(path.join(rootPath, "gradlew"), 0o775);
+      fs.chmodSync(path.join(rootPath, findGradleFile), 0o775);
     } catch (e) {}
-    gradleCmd = path.resolve(path.join(rootPath, "gradlew"));
+    gradleCmd = path.resolve(path.join(rootPath, findGradleFile));
   } else if (process.env.GRADLE_CMD) {
     gradleCmd = process.env.GRADLE_CMD;
   } else if (process.env.GRADLE_HOME) {
@@ -3161,19 +3167,25 @@ exports.getGradleCommand = getGradleCommand;
  */
 const getMavenCommand = (srcPath, rootPath) => {
   let mavenCmd = "mvn";
-  if (fs.existsSync(path.join(srcPath, "mvnw"))) {
+
+  let findMavenFile = "mvnw";
+  if (os.platform() == "win32") {
+    findGradleFile = "mvnw.bat";
+  }
+
+  if (fs.existsSync(path.join(srcPath, findMavenFile))) {
     // Use local maven wrapper if available
     // Enable execute permission
     try {
-      fs.chmodSync(path.join(srcPath, "mvnw"), 0o775);
+      fs.chmodSync(path.join(srcPath, findMavenFile), 0o775);
     } catch (e) {}
-    mavenCmd = path.resolve(path.join(srcPath, "mvnw"));
-  } else if (rootPath && fs.existsSync(path.join(rootPath, "mvnw"))) {
+    mavenCmd = path.resolve(path.join(srcPath, findMavenFile));
+  } else if (rootPath && fs.existsSync(path.join(rootPath, findMavenFile))) {
     // Check if the root directory has a wrapper script
     try {
-      fs.chmodSync(path.join(rootPath, "mvnw"), 0o775);
+      fs.chmodSync(path.join(rootPath, findMavenFile), 0o775);
     } catch (e) {}
-    mavenCmd = path.resolve(path.join(rootPath, "mvnw"));
+    mavenCmd = path.resolve(path.join(rootPath, findMavenFile));
   } else if (process.env.MVN_CMD || process.env.MAVEN_CMD) {
     mavenCmd = process.env.MVN_CMD || process.env.MAVEN_CMD;
   } else if (process.env.MAVEN_HOME) {


### PR DESCRIPTION
https://github.com/AppThreat/cdxgen/issues/157

When the code searches for gradlew, on windows it never looks for gradlew.bat. It does find gradlew, but that will fail to run in cmd/ps.

Per the request, the same change was made for maven, but I have **no** knowledge of how maven is setup, so this will need to be verified by someone who can, or I'll remove it as I only need gradlew working atm.

I do not have alternate OSs to test this on, so please keep that in mind.